### PR TITLE
tests: Enable `test_mock_quota_exceeded` test case again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
-      APIARY_URL: https://opsv31.docs.apiary.io/
+      APIARY_URL: ${{ secrets.OPS_APIARY_URL }}
       OPS_KEY: ${{ secrets.OPS_API_CONSUMER_KEY }}
       OPS_SECRET: ${{ secrets.OPS_API_CONSUMER_SECRET }}
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -49,16 +49,16 @@ You can either define them interactively using `export VARNAME=VALUE`, or store
 them into an `.env` file within the same directory you are running the tests from.
 See `example.env` for a blueprint.
 
-A public instance of the Mock Server API service is available at
-<https://opsv31.docs.apiary.io/>.
+The Apiary Mock Server API blueprint is available at <https://opsv31.docs.apiary.io/>.
 
 ```shell
-export APIARY_URL=https://opsv31.docs.apiary.io/
+export APIARY_URL=https://private-[SECRET]-opsv31.apiary-mock.com/
 export OPS_KEY=NKdGMmedZBGLRxTrUwCZMQCYp7Ak5a0u
 export OPS_SECRET=v3vARPu7DFPEDB8i
 ```
 
-_Note that the credentials are just for demonstration purposes, and invalid._
+_Note that the Apiary URL and the OPS credentials are just for demonstration
+purposes, and will not work._
 
 
 ### Basics

--- a/tests/test_ops_quota.py
+++ b/tests/test_ops_quota.py
@@ -16,7 +16,6 @@ def issue_request(client):
 
 
 # Tests
-@pytest.mark.skip(reason="FIXME: Currently fails")
 def test_mock_quota_exceeded(all_clients, monkeypatch):
     monkeypatch.setattr(all_clients, "__service_url_prefix__", APIARY_URL)
     errors = {


### PR DESCRIPTION
## About

This fixes GH-64, using the correct `APIARY_URL` value, which gets obtained from a corresponding GitHub workflow secret.
