### PR TITLE
Maintenance: This and that

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: [
+          "3.6",
+          "3.11",
+        ]
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Run linter and software tests
       run: |
-        make test-ci
+        make check-ci
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Add support for Python 3.10 and 3.11
+
 ## 4.0.0 (2021-09-19)
 
 - Upgrade dependencies

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ clean-pyc:
 
 lint: ## flake8 lint the project
 	flake8 epo_ops tests
+	black --check .
+	isort --check .
+
+format: ## Run code formatting
+	black .
+	isort .
 
 test: clean ## Run tests with virtualenv Python
 	py.test -s -v --lf --cov epo_ops tests --cov-report term-missing --cov-report xml

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ clean-pyc:
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 
+check: lint test        ## Run linter and software tests
+check-ci: lint test-ci  ## Run linter and software tests on CI
+
 lint: ## flake8 lint the project
 	flake8 epo_ops tests
 	black --check .

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -3,12 +3,11 @@
 
 ## Iteration +1
 
-- Use new organization name `ip-tools`
-- Dissolve `requirements` files, and inline them into `setup.py`
-- CI: Add GHA recipe, dissolve Travis configuration
 - Use `ruff` linter, dissolve `flake8` and `isort`
 - Use `versioningit` for versioning, dissolve `bumpversion`
 - Switch to `pyproject.toml`
+- Replace Apiary Mock server
+  https://github.com/ip-tools/python-epo-ops-client/issues/65
 - Setup project documentation on Read the Docs
 
 
@@ -25,3 +24,11 @@ This is the content of the original `TODOS.md` file.
 - Additional services
   - Legal service
 - Makefile: Comma in `echo` statements?
+
+
+## Done
+
+- Use new organization name `ip-tools`
+- CI: Add GHA recipe, dissolve Travis configuration
+- Dissolve `requirements` files, and inline them into `setup.py`
+- Add support for Python 3.10 and 3.11

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -78,6 +78,9 @@ system.
 
 ### Advanced Usage
 
+In order to run either the linter, or the software tests exclusively,
+use `make lint` vs. `make test`.
+
 To focus on specific parts of the code base, you run a subset of the software
 tests.
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -64,16 +64,14 @@ purposes, and will not work._
 ### Basics
 
 ```shell
-make test
-tox -e lint
-tox
+make check
 ```
 
 ⚠️ Note that the software tests need a working internet connection, in order to
 access both the OPS and the [OPS Apiary Mock Services][apiary ops] services.
 
-⚠️ Note that the `lint` testenv requires python3.8 to be present in your
-system.
+⚠️ Note that running the test suite using `tox` may still work, however we are
+planning to remove that configuration in the future.
 
 
 ### Advanced Usage

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -201,7 +201,7 @@ class Client(object):
         else:
             parts = parts_pre + parts_post
 
-        return u"/".join(filter(None, parts))
+        return "/".join(filter(None, parts))
 
     # Service requests
     # info: {service, reference_type, input, endpoint, constituents}

--- a/epo_ops/middlewares/throttle/storages/sqlite.py
+++ b/epo_ops/middlewares/throttle/storages/sqlite.py
@@ -125,8 +125,8 @@ class SQLite(Storage):
             return 0.0
         else:
             td = next_run - _now
-            ts = td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6
-            return ts / 10 ** 6
+            ts = td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6
+            return ts / 10**6
 
     def update(self, headers):
         "This method is a public interface for a throttle storage class"

--- a/epo_ops/models.py
+++ b/epo_ops/models.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 def _prepare_part(part):
-    return u"({0})".format(quote(part))
+    return "({0})".format(quote(part))
 
 
 class BaseInput(object):
@@ -28,7 +28,7 @@ class BaseInput(object):
         parts = filter(
             None, [self.country_code, self.number, self.kind_code, self.date]
         )
-        return u".".join(map(_prepare_part, parts))
+        return ".".join(map(_prepare_part, parts))
 
 
 class Original(BaseInput):

--- a/setup.py
+++ b/setup.py
@@ -46,19 +46,19 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     readme = f.read()
 
-with open(path.join(here, "CHANGELOG.md"), encoding="utf-8") as f:
-    history = f.read()
-
 setup(
     name="python-epo-ops-client",
     version=__version__,
     description=(
-        "Python Client for the European Patent Office's " "Open Patent Services API"
+        "Python client for EPO OPS, "
+        "the European Patent Office's Open Patent Services API."
     ),
     long_description_content_type="text/markdown",
-    long_description=u"{}\n{}".format(readme, history),
+    long_description=readme,
     author="George Song",
     author_email="george@monozuku.com",
+    maintainer="Andreas Motl",
+    maintainer_email="andreas.motl@ip-tools.org",
     url="https://github.com/ip-tools/python-epo-ops-client",
     download_url=(
         "https://github.com/ip-tools/python-epo-ops-client/archive/"
@@ -84,4 +84,14 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    keywords=[
+        "ops",
+        "epo",
+        "epo-ops",
+        "patent-data",
+        "patent-office",
+        "patent-data-api",
+        "european patent office",
+        "open patent services",
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -95,5 +95,5 @@ setup(
         "patent-data-api",
         "european patent office",
         "open patent services",
-    ]
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, lint
+envlist = py36, py37, py38, py39
 
 [testenv]
 setenv =
@@ -10,15 +10,3 @@ setenv =
 whitelist_externals = make
 commands =
   make test
-
-[testenv:lint]
-basepython = python3.8
-deps =
-  black
-  flake8
-  flake8-bugbear
-  isort
-commands =
-  black --check .
-  isort . --check
-  make lint


### PR DESCRIPTION
A few little things on maintenance improvements, submitted together.

- build: Add linter steps to Makefile, and new `make format` target
- ci: Use `make check-ci` for running linters and tests on GHA
- project: Slightly improve `setup.py`
    - Do not append change log to `long_description`
    - Add maintainer contact
    - Add a few keywords
- build: Add support for Python 3.10 and 3.11
- docs: Update backlog
- chore: Format code using `black` and `isort`
- ci: Temporarily remove intermediary Python versions to save resources
    For the next iterations, just run tests on Python 3.6 and 3.11. In order
    to re-enable full coverage, the omitted versions will be re-added after
    the modernization is finished.
