### PR TITLE
Chore: Update release instructions / recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,18 +53,16 @@ coverage: clean ## Check code coverage locally
 	open htmlcov/index.html
 
 release: clean # Package and upload a release to PyPI
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build
 	twine check dist/*
 	twine upload --repository pypi dist/*
-	open https://pypi.python.org/pypi/python-epo-ops-client
+	open https://pypi.org/project/python-epo-ops-client/
 
 release-test: clean # Package and upload a release to testpypi
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build
 	twine check dist/*
 	twine upload --repository testpypi dist/*
-	open https://testpypi.python.org/pypi/python-epo-ops-client
+	open https://test.pypi.org/project/python-epo-ops-client/
 
 sdist: clean
 	python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ requires = [
 extras = {
     "develop": [
         "black<24",
+        "build<2",
         "ruff==0.0.285; python_version >= '3.7'",
         "twine<5",
         "wheel<1",


### PR DESCRIPTION
## About

Maintenance update of release instructions, in order to synchronize it with how the recent release 4.1.0 was built and published.

## Details

It now uses the canonical `build` package for building both source-, and binary wheel packages to be uploaded to PyPI.

-- https://pypi.org/project/build/