### PR TITLE
Chore: Trim `setup.py`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,8 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-import os
-import sys
 from codecs import open
 from os import path
 
 from setuptools import setup
 from versioningit import get_cmdclasses
-
-if sys.argv[-1] == "publish":
-    # FIXME: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
-    # FIXME: S607 Starting a process with a partial executable path
-    os.system("python setup.py sdist upload")  # noqa: S605, S607
-    sys.exit()
-
-packages = ["epo_ops"]
-
-requires = [
-    "dogpile.cache<1.2",
-    "importlib-metadata; python_version<'3.8'",
-    "python-dateutil<2.9",
-    "requests>=2.27,<3",
-    "six<2",
-]
-extras = {
-    "develop": [
-        "black<24",
-        "build<2",
-        "ruff==0.0.285; python_version >= '3.7'",
-        "twine<5",
-        "wheel<1",
-    ],
-    "test": [
-        "pytest<8",
-        "pytest-cache<2",
-        "pytest-cov<4.2",
-        "python-dotenv<0.20",
-        "responses<0.24",
-    ],
-}
 
 here = path.abspath(path.dirname(__file__))
 
@@ -61,12 +24,31 @@ setup(
     maintainer_email="andreas.motl@ip-tools.org",
     url="https://github.com/ip-tools/python-epo-ops-client",
     download_url="https://pypi.org/project/python-epo-ops-client/#files",
-    packages=packages,
+    packages=["epo_ops"],
     package_dir={"epo_ops": "epo_ops"},
     include_package_data=True,
-    install_requires=requires,
-    extras_require=extras,
-    tests_require=extras["test"],
+    install_requires=[
+        "dogpile.cache<1.2",
+        "importlib-metadata; python_version<'3.8'",
+        "python-dateutil<2.9",
+        "requests>=2.27,<3",
+        "six<2",
+    ],
+    extras_require={
+        "develop": [
+            "black<24",
+            "ruff==0.0.285; python_version >= '3.7'",
+            "twine<5",
+            "wheel<1",
+        ],
+        "test": [
+            "pytest<8",
+            "pytest-cache<2",
+            "pytest-cov<4.2",
+            "python-dotenv<0.20",
+            "responses<0.24",
+        ],
+    },
     zip_safe=False,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## About

Other than trimming the `setup.py` file a bit, also inline requirements again, because apparently, Dependabot does not pick them up. This patch accompanies another cleanup patch, GH-78.
