### PR TITLE
Tests: Skip OPS-based integration tests when no credentials are defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,13 @@ format: ## Run code formatting
 	black .
 
 test: clean ## Run tests with virtualenv Python
-	py.test -s -v --lf --cov epo_ops tests --cov-report term-missing --cov-report xml
+	pytest --lf
 
 test-ci: clean ## Run tests in CI environment with virtualenv Python
-	py.test -v --cov epo_ops tests --cov-report term-missing --cov-report xml
+	pytest
 
-coverage: clean ## Check code coverage locally
-	py.test -s -v --cov epo_ops tests --cov-report term-missing --cov-report xml --cov-report html
+coverage: clean test-ci ## Check code coverage locally
+	coverage html
 	open htmlcov/index.html
 
 release: clean # Package and upload a release to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,18 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+minversion = "2.0"
+addopts = """
+  -rsfEX -p pytester --strict-markers --verbosity=3
+  --cov=epo_ops tests --cov-report=term-missing --cov-report=xml
+  """
+log_level = "DEBUG"
+log_cli_level = "DEBUG"
+testpaths = ["tests"]
+xfail_strict = true
+markers = [
+]
 
 [tool.ruff]
 line-length = 80

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from .helpers import mkcache, mksqlite, mkthrottler
-from .secrets import OPS_KEY, OPS_SECRET
+from .secrets import get_secrets_or_skip_tests
 
 
 @pytest.fixture
@@ -13,8 +13,9 @@ def storage(request):
 def reset_cached_client(request):
     from epo_ops import Client
 
+    ops_key, ops_secret = get_secrets_or_skip_tests()
     return Client(
-        OPS_KEY, OPS_SECRET, middlewares=[mkcache(request), mkthrottler(request)]
+        ops_key, ops_secret, middlewares=[mkcache(request), mkthrottler(request)]
     )
 
 
@@ -32,14 +33,18 @@ def module_cache(request):
 def default_client(request):
     from epo_ops import Client
 
-    return Client(OPS_KEY, OPS_SECRET, middlewares=[mkthrottler(request)])
+    ops_key, ops_secret = get_secrets_or_skip_tests()
+
+    return Client(ops_key, ops_secret, middlewares=[mkthrottler(request)])
 
 
 @pytest.fixture(scope="module")
 def cached_client(request, module_cache):
     from epo_ops import Client
 
-    return Client(OPS_KEY, OPS_SECRET, middlewares=[module_cache, mkthrottler(request)])
+    ops_key, ops_secret = get_secrets_or_skip_tests()
+
+    return Client(ops_key, ops_secret, middlewares=[module_cache, mkthrottler(request)])
 
 
 @pytest.fixture(scope="module", params=["cached_client", "default_client"])

--- a/tests/secrets.py
+++ b/tests/secrets.py
@@ -9,6 +9,7 @@ from __future__ import (
 import os
 from os.path import abspath, dirname, join
 
+import pytest
 from dotenv import load_dotenv
 
 # Prune environment variables.
@@ -20,6 +21,13 @@ for k in ("OPS_KEY", "OPS_SECRET"):
 dotenv_path = abspath(join(dirname(__file__), "../.env"))
 load_dotenv(dotenv_path)
 
+
 # Set environment variables as constants.
-OPS_KEY = os.environ["OPS_KEY"]
-OPS_SECRET = os.environ["OPS_SECRET"]
+def get_secrets_or_skip_tests():
+    try:
+        ops_key = os.environ["OPS_KEY"]
+        ops_secret = os.environ["OPS_SECRET"]
+    except KeyError as ex:
+        raise pytest.skip("No OPS credentials configured") from ex
+
+    return ops_key, ops_secret


### PR DESCRIPTION
## Problem

GH-81 demonstrated that the software tests run on behalf of GHA fail on external contributions, because they do not have access to the OPS credentials per GitHub Actions Secrets. Bummer.

## Solution

This patch will make running OPS-based tests optional. That this decreases the coverage of the code base, is unfortunate, but at least, tests will stop failing on CI. C'est la vie.

## Outlook

A possible solution for a subsequent iteration would be to emulate/mock a OPS service backend, so integration tests could be synthesized. I think @gsong may have used such a technique on a previous version?
