### PR TITLE
Added docstring and type annotations to family(), removed parameter endpoint

### DIFF
--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -56,6 +56,19 @@ class Client(object):
 
         Returns:
             requests.Response: a requests.Response object.
+
+        Examples:
+            >>> response = client.family('publication', epo_ops.models.Epodoc('EP1000000'))
+            >>> response
+            <Response [200]>
+            >>> len(response.text)
+            8790
+
+            >>> response_with_constituents = client.family('publication', epo_ops.models.Epodoc('EP1000000'), None, ['biblio', 'legal'])
+            >>> response_with_constituents
+            <Response [200]>
+            >>> len(response_with_constituents.text)
+            160206
         """
         if endpoint is not None:
             warnings.warn(

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 from base64 import b64encode
+from typing import List, Optional, Union
 from xml.etree import ElementTree as ET
 
 import requests
@@ -8,7 +9,14 @@ from requests.exceptions import HTTPError
 
 from . import exceptions
 from .middlewares import Throttler
-from .models import NETWORK_TIMEOUT, AccessToken, Request
+from .models import (
+    NETWORK_TIMEOUT,
+    AccessToken,
+    Docdb,
+    Epodoc,
+    Original,
+    Request,
+)
 
 log = logging.getLogger(__name__)
 
@@ -35,13 +43,32 @@ class Client(object):
         self.secret = secret
         self._access_token = None
 
-    def family(self, reference_type, input, endpoint=None, constituents=None):
+    def family(
+        self,
+        reference_type: str,
+        input: Union[Docdb, Epodoc],
+        endpoint=None,
+        constituents: Optional[List[str]] = None,
+    ):
+        """
+        Retrieves the patent numbers of the extended patent family related to the input (INPADOC family).
+
+        Args:
+            reference_type (str): Any of "publication", "application", or "priority".
+            input (Epodoc or Docdb): The document number. Cannot be Original.
+            endpoint (optional): None. Not applicable for family service.
+            constituents (list[str], optional): List of 'biblio', 'legal' or both.
+                                                Defaults to None.
+
+        Returns:
+            Response: a requests.Response object
+        """
         url = self._make_request_url(
             dict(
                 service=self.__family_path__,
                 reference_type=reference_type,
                 input=input,
-                endpoint=endpoint,
+                endpoint=None,
                 constituents=constituents,
                 use_get=True,
             )

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -9,14 +9,7 @@ from requests.exceptions import HTTPError
 
 from . import exceptions
 from .middlewares import Throttler
-from .models import (
-    NETWORK_TIMEOUT,
-    AccessToken,
-    Docdb,
-    Epodoc,
-    Original,
-    Request,
-)
+from .models import NETWORK_TIMEOUT, AccessToken, Docdb, Epodoc, Request
 
 log = logging.getLogger(__name__)
 

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -47,7 +47,6 @@ class Client(object):
         self,
         reference_type: str,
         input: Union[Docdb, Epodoc],
-        endpoint=None,
         constituents: Optional[List[str]] = None,
     ):
         """
@@ -56,7 +55,6 @@ class Client(object):
         Args:
             reference_type (str): Any of "publication", "application", or "priority".
             input (Epodoc or Docdb): The document number. Cannot be Original.
-            endpoint (optional): None. Not applicable for family service.
             constituents (list[str], optional): List of 'biblio', 'legal' or both.
                                                 Defaults to None.
 

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -51,20 +51,20 @@ class Client(object):
             reference_type (str): Any of "publication", "application", or "priority".
             input (Epodoc or Docdb): The document number. Cannot be Original.
             endpoint (optional): None. Not applicable for family service.
-            constituents (list[str], optional): List of 'biblio', 'legal' or both.
+            constituents (list[str], optional): List of "biblio", "legal" or both.
                                                 Defaults to None.
 
         Returns:
             requests.Response: a requests.Response object.
 
         Examples:
-            >>> response = client.family('publication', epo_ops.models.Epodoc('EP1000000'))
+            >>> response = client.family("publication", epo_ops.models.Epodoc("EP1000000"))
             >>> response
             <Response [200]>
             >>> len(response.text)
             8790
 
-            >>> response_with_constituents = client.family('publication', epo_ops.models.Epodoc('EP1000000'), None, ['biblio', 'legal'])
+            >>> response_with_constituents = client.family("publication", epo_ops.models.Epodoc("EP1000000"), None, ["biblio", "legal"])
             >>> response_with_constituents
             <Response [200]>
             >>> len(response_with_constituents.text)

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import warnings
 from base64 import b64encode
 from typing import List, Optional, Union
 from xml.etree import ElementTree as ET
@@ -40,20 +41,29 @@ class Client(object):
         self,
         reference_type: str,
         input: Union[Docdb, Epodoc],
+        endpoint=None,
         constituents: Optional[List[str]] = None,
-    ):
+    ) -> requests.Response:
         """
         Retrieves the patent numbers of the extended patent family related to the input (INPADOC family).
 
         Args:
             reference_type (str): Any of "publication", "application", or "priority".
             input (Epodoc or Docdb): The document number. Cannot be Original.
+            endpoint (optional): None. Not applicable for family service.
             constituents (list[str], optional): List of 'biblio', 'legal' or both.
                                                 Defaults to None.
 
         Returns:
-            Response: a requests.Response object
+            requests.Response: a requests.Response object.
         """
+        if endpoint is not None:
+            warnings.warn(
+                "The `endpoint` argument is not used in this context and will be removed.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         url = self._make_request_url(
             dict(
                 service=self.__family_path__,

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -102,7 +102,15 @@ class Client(object):
         """
         Retrieve the image page for a given path, one page at a time.
         The path needs to be retrieved from the xml resulting from a prior inquiry using
-        the published_data() service with the endpoint='images'.
+        the published_data() service with the 'endpoint="images"' argument.
+
+        Args:
+            path (str): contained in the 'link' attribute of the document instance element (inquiry xml).
+            range (int, optional): the number of the image page to be fetched. Defaults to 1.
+            document_format (str, optional): depends on the inquiry response. Defaults to "application/tiff".
+
+        Returns:
+            requests.Response: a requests.Response object.
         """
         return self._image_request(path, range, document_format)
 
@@ -110,17 +118,50 @@ class Client(object):
         self,
         reference_type: str,
         input: Union[Original, Docdb, Epodoc],
-        output_format: Union[Original, Docdb, Epodoc],
+        output_format: str,
     ) -> requests.Response:
         """
         This service converts a patent number from one input format into another format.
 
-        Use-cases: Given that other OPS services use only the Epodoc or Docdb format,
-        the general use-case of this method would be to convert the Original format
-        into either the Docdb or the Epodoc format.
+        Args:
+            reference_type (str): Any of "publication", "application", or "priority".
+            input (Original, Epodoc or Docdb): The document number as a data object.
+            output_format (str): Any of "original", "epodoc" or "docdb".
 
-        Note: It is especially important to include the date in number requests whenever
-        possible because number formatting may vary depending on the date.
+        Returns:
+            requests.Response: a requests.Response object.
+
+
+        Examples:
+            # from JP original to docdb
+            >>> response = client.number(
+                    "application",
+                    Original(number="2006-147056", country_code="JP", kind_code="A", date="20060526"),
+                    "docdb,
+                )
+
+            # from US original to epodoc
+            >>> response = client.number(
+                    "application",
+                    Original("08/921,321", "US", "A", "19970829"),
+                    "epodoc",
+                )
+
+            # from PCT original to docdb
+            >>> response = client.number(
+                    "application",
+                    Original("PCT/GB02/04635", date="19970829"),
+                    "docdb",
+                )
+
+        Use-cases:
+            Given that other OPS services use only the Epodoc or Docdb format,
+            the general use-case of this method is to convert the Original format
+            into either the Docdb or the Epodoc format.
+
+        Note:
+            It is especially important to include the date of publication in the input
+            whenever possible because number formatting may vary depending on the date.
         """
         possible_conversions = {
             "docdb": ["original", "epodoc"],
@@ -160,7 +201,7 @@ class Client(object):
             constituents (list[str], optional): List of "biblio", "abstract", "images", "full cycle".
 
         Returns:
-            requests.Response: a requests.Response object
+            requests.Response: a requests.Response object.
 
         Note:
         1) input cannot be a models.Original


### PR DESCRIPTION
Starting with type annotations.
Acc. to ops specs, endpoint is not used in family service. Not used in tests either. Options: either document it in docstring or remove it. Went for second option.
The type annotations are acc. to python 3.6 (although commit comment says py3.8).