### PR TITLE
updated urls of dogpile.cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ details.
 
 [apache license]: http://www.apache.org/licenses/LICENSE-2.0
 [developer's area]: https://developers.epo.org/ops-v3-2/apis
-[dogpile.cache region]: http://dogpilecache.readthedocs.org/en/latest/api.html#module-dogpile.cache.region
-[dogpile.cache]: https://bitbucket.org/zzzeek/dogpile.cache
+[dogpile.cache region]: https://dogpilecache.sqlalchemy.org/en/latest/usage.html#using-a-region
+[dogpile.cache]: https://github.com/sqlalchemy/dogpile.cache
 [epo]: http://epo.org
 [ops guide]: https://link.epo.org/web/ops_v3.2_documentation_-_version_1.3.19_en.pdf
 [ops]: https://www.epo.org/searching-for-patents/data/web-services/ops.html


### PR DESCRIPTION
fixed outdated links to dogpile.cache repository and dogpile.cache documentation