### PR TITLE
CI: Stage release packages to PyPI through GHA

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,68 @@
+# Stage Python source distribution and wheel packages through GitHub Actions (GHA) to Python Package Index (PyPI).
+name: "Release: Python package"
+
+on:
+
+  # Build and publish packages when running a release.
+  push:
+    tags:
+      - '*'
+
+  # Build packages on each pull request for validation purposes.
+  pull_request:
+
+  # Build packages each night for validation purposes.
+  schedule:
+    - cron: '0 4 * * *'
+
+  # Allow the job to be triggered manually.
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: "Build and publish to PyPI"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.13"]
+    env:
+      OS_TYPE: ${{ matrix.os }}
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      UV_SYSTEM_PYTHON: true
+
+    # Trusted publishing.
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          cache-dependency-glob: |
+            setup.py
+            pyproject.toml
+          cache-suffix: ${{ matrix.python-version }}
+          enable-cache: true
+          version: "latest"
+
+      - name: Build package
+        run: |
+          uv pip install build
+          python -m build
+
+      - name: Publish package to PyPI
+        if: startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,19 @@
+# Release
+
+Building Python packages and publishing to PyPI is automated
+using the GHA workflow `release-pypi.yml`.
+
+To release the package, exercise those steps:
+
+- Edit `CHANGELOG.md`, designating a new version. Commit the file
+  using a commit message like `Release 4.1.1`.
+
+- Create a tag using the new version, including a `v` prefix, e.g.
+  ```shell
+  git tag v4.1.1
+  ```
+
+- Push to remote.
+  ```shell
+  git push --follow-tags
+  ```

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     maintainer_email="andreas.motl@ip-tools.org",
     url="https://github.com/ip-tools/python-epo-ops-client",
     download_url="https://pypi.org/project/python-epo-ops-client/#files",
-    packages=["epo_ops"],
+    packages=["epo_ops", "epo_ops.middlewares"],
     package_dir={"epo_ops": "epo_ops"},
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
## About

Let's use [trusted publishing](https://docs.pypi.org/trusted-publishers/) to stage packages to PyPI through GHA.

<img width="406" height="116" alt="image" src="https://github.com/user-attachments/assets/c7319fb4-5cb0-431a-9867-8655f7b7d3f8" />

-- https://pypi.org/manage/project/python-epo-ops-client/settings/publishing/